### PR TITLE
Install node dependencies before running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,5 +21,14 @@ jobs:
         bundle config path vendor/bundle
         bundle check || bundle install --jobs=4 --retry=3
 
+    - name: Set up Nodejs
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.19.x
+
+    - name: Install npm dependencies
+      run: |
+        npm install
+
     - name: Run tests
       run: bundle exec rspec spec


### PR DESCRIPTION
This is needed in order to install the `govuk-frontend` npm package.