### PR TITLE
Collapse multiple white space characters

### DIFF
--- a/lib/govuk-frontend/tag.rb
+++ b/lib/govuk-frontend/tag.rb
@@ -12,9 +12,9 @@ module GovukFrontend
 
     tag.strong(
       safe_join([
-        "\n  ".html_safe,
+        " ".html_safe,
         (params["html"] ? params["html"].html_safe : params["text"]),
-        "\n".html_safe
+        " ".html_safe
       ]),
       **attributes.symbolize_keys
     )

--- a/lib/govuk-frontend/warning_text.rb
+++ b/lib/govuk-frontend/warning_text.rb
@@ -13,17 +13,17 @@ module GovukFrontend
     attributes["class"] += " #{classes}" if classes
 
     tag.div(class: attributes["class"], **attributes.symbolize_keys) do
-      "\n  ".html_safe +
+      " ".html_safe +
       tag.span('!', class: 'govuk-warning-text__icon', :"aria-hidden" => 'true') +
-      "\n  ".html_safe +
+      " ".html_safe +
       content_tag('strong', class: 'govuk-warning-text__text') do
-        "\n    ".html_safe +
+        " ".html_safe +
         content_tag('span', iconFallbackText, class: 'govuk-warning-text__assistive') +
-          "\n    ".html_safe +
+          " ".html_safe +
           (params["html"] ? params["html"].html_safe : params["text"]) +
-          "\n  ".html_safe
+          " ".html_safe
       end +
-      "\n".html_safe
+      " ".html_safe
     end
 
   end

--- a/spec/govuk-frontend/tag_spec.rb
+++ b/spec/govuk-frontend/tag_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe "tag" do
   it "outputs the right html" do
     fixtures("tag").each do |example|
-      expect(govukTag(example["options"])).to eq(example["html"]), "HTML for example '#{example["name"]}' doesn’t match"
+      expect(govukTag(example["options"])).to match_html_of(example["html"])
     end
   end
 end

--- a/spec/govuk-frontend/warning_text_spec.rb
+++ b/spec/govuk-frontend/warning_text_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe "warning text" do
   it "outputs the right html" do
     fixtures("warning-text").each do |example|
-      expect(govukWarningText(example["options"])).to eq(example["html"]), "HTML for example '#{example["name"]}' doesn’t match"
+      expect(govukWarningText(example["options"])).to match_html_of(example["html"])
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,3 +9,13 @@ def fixtures(component_name)
 
   JSON.parse(file)["fixtures"]
 end
+
+
+RSpec::Matchers.define :match_html_of do |expected|
+  match do |actual|
+    actual.gsub(/\s+/, " ") == expected.gsub(/\s+/, " ")
+  end
+  failure_message do |actual|
+    "expected:\n\n#{actual.gsub(/\s+/, " ")}\n\nto be the same as\n\n#{expected.gsub(/\s+/, " ")}"
+  end
+end


### PR DESCRIPTION
Successive white space characters within HTML elements don't have any effect in web browsers, and so it should be safe to collapse multiple white space (including new line) charactes into a single space.

This enables the implementation of the components to be simpler, only inserting a single space between elements instead of exactly the right number of spaces and newlines.

This approach has been adopted by @natcarey at HMRC, and they've not had any issues with it so far.